### PR TITLE
get_model in django 1.7

### DIFF
--- a/select2/models/base.py
+++ b/select2/models/base.py
@@ -52,7 +52,7 @@ class SortableThroughModelBase(ModelBase):
         # Create a callbable using closure variables that returns
         # get_model() for this model
         def get_model():
-            return models.get_model(app_label, name, False)
+            return models.get_model(app_label, name)
         # Pass the callable to SimpleLazyObject
         lazy_model = SimpleLazyObject(get_model)
         # And set the auto_created to a lazy-loaded model object


### PR DESCRIPTION
Change in django 1.7 : apps.get_model(app_label, model_name) :

  File "/home/**_/local/lib/python2.7/site-packages/django/apps/registry.py", line 183, in get_models
    include_auto_created, include_deferred, include_swapped)))
  File "/home/_**/local/lib/python2.7/site-packages/django/apps/config.py", line 187, in get_models
    if model._meta.auto_created and not include_auto_created:
  File "/home/___/local/lib/python2.7/site-packages/django/utils/functional.py", line 224, in inner
    self._setup()
  File "/home/___/local/lib/python2.7/site-packages/django/utils/functional.py", line 357, in _setup
    self._wrapped = self._setupfunc()
  File "/home/___/local/lib/python2.7/site-packages/select2/models/base.py", line 55, in get_model
    return models.get_model(app_label, name, False)
  File "/home/___/local/lib/python2.7/site-packages/django/db/models/__init__.py", line 54, in alias
    return getattr(loading, function_name)(_args, *_kwargs)
TypeError: get_model() takes at most 3 arguments (4 given)
